### PR TITLE
29 the bottom of the text in the hero section is cut off on windows pcs

### DIFF
--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -19,7 +19,7 @@ const HeroSection = () => {
                         Hello, I&apos;m{" "}
                     </span>
                     <br />
-                    <div className='h-44 sm:h-52 md:h-40 lg:h-515 xl:h-96 overflow-hidden'>
+                    <div className='h-44 sm:h-52 md:h-40 lg:h-520 2xl:h-96 overflow-hidden'>
                         <TypeAnimation
                             sequence={[
                                 // Same substring at the start will only be typed out once, initially

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
       height: {
-        515: '515px', // カスタムの高さ値
+        520: '520px', // カスタムの高さ値
       },
       screens: {
         'xs': '324px', // Samsung Galaxy Fold


### PR DESCRIPTION
## Cause
The heigh of the range between xl and 2xl was not high enough.

## Solution
Unify the height of the relevant range as lg or higer.